### PR TITLE
Fixed link that lead to nowhere

### DIFF
--- a/views/home.ejs
+++ b/views/home.ejs
@@ -33,7 +33,7 @@
 	<div class="container">
 		<% teamData.forEach(function(team) { %>
 			<div class="card shadow p-1 mb-4 sm-white rounded"> <img class="mr-3" src="<%= team.logo %>" alt="Card image cap"> <span id="teamtext"><%= team.team %></span>
-				<a class="stretched-link" href="teams"></a>
+				<a class="stretched-link" href=<%= `http://localhost:3000/teams/${team.id}` %>></a>
 			</div>
 			<% }); %>
 	</div>


### PR DESCRIPTION
Changed link on "home" so that it leads to a page displaying team roster instead of an error page.