### PR TITLE
Fixed teamcard centering upon changes in the viewport

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -7,7 +7,8 @@
 #teamCard {
     width: 25rem;
     display:inline-block;
-    margin-right:25px;
+    margin: auto;
+    margin-bottom: 1.5rem;
 }
 
 #teamtext {

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -4,24 +4,28 @@
     <div class="text-center">
 		<a href="/"><img src="/images/nba-logo.svg" alt="NBA logo" id="logoNBA" /></a>
     </div>
-	<div class="container">
+
+  <div class="container">
+	  <div class="container-fluid">
+    <div class="row justifiy-content-evenly">
 	 <!-- TEAM CARD -->
 	<%# EJS CODE %>
 
-	<% teamData.forEach(function(team) { %> 
-		<div class="card shadow p-1 mb-4 sm-white rounded" id="teamCard">
-			<img class="mr-3" src="<%= team.logo %>" alt="Card image cap" />
-			<span id="teamtext"><%= team.team %> </span>
-			<% var teampath= team.team; 
-			teampath=teampath.split(" ").join("_");
-			teampath=teampath.toLowerCase();
-			teampath="/teams/"+teampath;
-			%> 
-			<a class="stretched-link" href="<%= teampath %>"></a>
-	  	</div>
-	<% }); %> 
-
+  	<% teamData.forEach(function(team) { %>
+  		<div class="col-lg-3 col-md-3 col-sm-12 card shadow" id="teamCard">
+  			<img class="mr-3" src="<%= team.logo %>" alt="Card image cap" />
+  			<span id="teamtext"><%= team.team %> </span>
+  			<% var teampath= team.team;
+  			teampath=teampath.split(" ").join("_");
+  			teampath=teampath.toLowerCase();
+  			teampath="/teams/"+teampath;
+  			%>
+  			<a class="stretched-link" href="<%= teampath %>"></a>
+  	  	</div>
+  	<% }); %>
 	<%# END EJS CODE %>
 	</div>
-   
+  </div>
+</div>
+
  <%- include("partials/footer.ejs") %>


### PR DESCRIPTION
Main changes were done in views/home.ejs to add a subcontainer "fluid" class inside of the original container to maintain column centering upon changes in the viewport. 

An additional row class was made with display type flex and bootstrap elements "justify-content-evenly" removes the need to add specific margins on each playercard, so that was set to auto in styles.css instead. 