### PR TITLE
Added floating headshots on playerCards in teamPage

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -6,6 +6,8 @@
 
 #teamLogo {
   margin-bottom: 5rem;
+  height: 200px;
+  width: 200px;
 }
 
 .teamPage-container {
@@ -33,12 +35,11 @@
 
 #playerCard {
     width: 20rem;
-    height: 25rem;
     display:inline-block;
     text-align: center;
     margin: auto;
     margin-bottom: 8rem;
-
+    color: var(--teamColor);
     /* test */
     position: relative;
 
@@ -97,6 +98,10 @@
   font-size: 0.8em;
 }
 
+.stat-title-text {
+  color: blue;
+}
+
 .fa {
     font-size: 20px !important;
 }
@@ -122,7 +127,8 @@
 
 /* Social Media Icon Styling */
 .icon-bar {
-  margin-top: 8em;
+  margin-top: 1.25rem;
+  margin-bottom: 0.5rem;
 }
 
 .btn-social {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -4,6 +4,15 @@
     padding-bottom:1.5em;
 }
 
+#teamLogo {
+  margin-bottom: 5rem;
+}
+
+.teamPage-container {
+  padding-left: 7em;
+  padding-right: 7em;
+}
+
 #teamCard {
     width: 25rem;
     display:inline-block;
@@ -23,15 +32,69 @@
 }
 
 #playerCard {
-    width: 25rem;
+    width: 20rem;
+    height: 25rem;
     display:inline-block;
     text-align: center;
     margin: auto;
-    margin-bottom: 1.5rem;
+    margin-bottom: 8rem;
+
+    /* test */
+    position: relative;
+
 }
 
+.image-cropper {
+  width: 125px;
+  height: 125px;
+  position: absolute;
+  overflow: hidden;
+  border-radius: 50%;
+  background-color: white;
+  top: -15%;
+  Left: 30%;
+}
+
+.image-cropper-subContainer {
+  height: 100px;
+  width: 100px;
+  position: absolute;
+  overflow: hidden;
+  /* border-radius: 50%; */
+  background-color: white;
+  Left: 10%;
+  top: 10%;
+}
+
+/* test */
 #playerImage {
-    width: 15rem;
+    width: 8rem;
+    position: relative;
+    Right: 12%;
+    /* position: absolute;
+    top:-25%;
+    left: 15%;
+    border: 3px solid #fff;
+    background: url(../images/white-img.png) */
+}
+
+#playerInfo {
+  margin-top: 5rem;
+}
+
+.card-body h4 {
+  font-size: 1.6rem;
+}
+
+.playerStats {
+  margin-top: 1em;
+}
+
+.card-body h5 {
+}
+
+.card-body h6 {
+  font-size: 0.8em;
 }
 
 .fa {
@@ -59,7 +122,7 @@
 
 /* Social Media Icon Styling */
 .icon-bar {
-  margin-top: 2em;
+  margin-top: 8em;
 }
 
 .btn-social {

--- a/views/teamPage.ejs
+++ b/views/teamPage.ejs
@@ -4,11 +4,11 @@
     <br>
     <div class="text-center">
       <h1 class="display-2"><%= team[0].team %></h1>
-      <img height="200px" width="200px" src="<%= team[0].teamLogo %>">
+      <img height="200px" width="200px" id="teamLogo" src="<%= team[0].teamLogo %>">
     </div>
     <br>
 
-    <div class="container">
+    <div class="container teamPage-container">
       <div class="container-fluid">
         <div class="row justify-content-evenly">
 
@@ -18,15 +18,33 @@
           <% team.slice(1).forEach(function(player) { %>
           <div class="col-lg-3 col-md-3 col-sm-12 card shadow" id="playerCard">
 
+            <div class="image-cropper shadow">
+            <div class ="image-cropper-subContainer">
             <% if(player.headshot){ %> <%# IF TWITTER ACCOUNT EXISTS  %>
             <img class="card-img-top rounded-circle" id="playerImage" src="<%= player.headshot %>">
             <% } else{ %>
             <img class="card-img-top rounded-circle" id="playerImage" src="/images/generic-player.png">
             <% } %>
+            </div>
+            </div>
 
-            <div class="card-body">
-              <h5 class="card-title"><%= player.name %> </h5>
-              <h6 class="card-text"><%= player.position %> | <%= player.jersey %> </h6>
+            <div class="card-body" id="playerInfo">
+              <h4 class="card-title"><%= player.name %> </h4>
+
+              <div class="playerStats">
+                <h5 class="card-text"><%= player.position %> | <%= player.jersey %> </h5>
+              </div>
+
+              <!-- <div class="d-flex justify-content-evenly playerStats"> -->
+                <!-- <div class="playerStats-subContainer"> -->
+                  <!-- <h5 class="card-text"><%= player.position %></h5> -->
+                  <!-- <h6 class="stat-title-text">Position</h6> -->
+                <!-- </div> -->
+                <!-- <div class="playerStats-subContainer"> -->
+                  <!-- <h5 class="card-text"><%= player.jersey %></h5> -->
+                  <!-- <h6 class="stat-title-text">Jersey No.</h6> -->
+                <!-- </div> -->
+              <!-- </div> -->
 
               <div class="d-flex justify-content-center icon-bar">
 

--- a/views/teamPage.ejs
+++ b/views/teamPage.ejs
@@ -4,7 +4,7 @@
     <br>
     <div class="text-center">
       <h1 class="display-2"><%= team[0].team %></h1>
-      <img height="200px" width="200px" id="teamLogo" src="<%= team[0].teamLogo %>">
+      <img id="teamLogo" src="<%= team[0].teamLogo %>">
     </div>
     <br>
 
@@ -16,7 +16,7 @@
           <%# EJS CODE %>
 
           <% team.slice(1).forEach(function(player) { %>
-          <div class="col-lg-3 col-md-3 col-sm-12 card shadow" id="playerCard">
+          <div class="col-lg-3 col-md-3 col-sm-12 card shadow" id="playerCard" style="--teamColor: #<%= team[0].teamColor %>">
 
             <div class="image-cropper shadow">
             <div class ="image-cropper-subContainer">
@@ -29,22 +29,19 @@
             </div>
 
             <div class="card-body" id="playerInfo">
-              <h4 class="card-title"><%= player.name %> </h4>
+              <h5 class="card-title"><%= player.name %> </h5>
 
-              <div class="playerStats">
-                <h5 class="card-text"><%= player.position %> | <%= player.jersey %> </h5>
+
+              <div class="d-flex justify-content-evenly playerStats">
+                <div class="playerStats-subContainer">
+                  <h5 class="card-text"><%= player.jersey %></h5>
+                  <h6 class="stat-title-text">Jersey No.</h6>
+                </div>
+                <div class="playerStats-subContainer">
+                  <h5 class="card-text"><%= player.position %></h5>
+                  <h6 class="stat-title-text">Position</h6>
+                </div>
               </div>
-
-              <!-- <div class="d-flex justify-content-evenly playerStats"> -->
-                <!-- <div class="playerStats-subContainer"> -->
-                  <!-- <h5 class="card-text"><%= player.position %></h5> -->
-                  <!-- <h6 class="stat-title-text">Position</h6> -->
-                <!-- </div> -->
-                <!-- <div class="playerStats-subContainer"> -->
-                  <!-- <h5 class="card-text"><%= player.jersey %></h5> -->
-                  <!-- <h6 class="stat-title-text">Jersey No.</h6> -->
-                <!-- </div> -->
-              <!-- </div> -->
 
               <div class="d-flex justify-content-center icon-bar">
 


### PR DESCRIPTION
Added various containers & sub containers to have a floating headshot for each playerCard in teamPage.ejs. 
In correspondance with the containers & sub containers, styles.css was modified accordingly. 

KNOWN issue:
- Responsiveness on mobile needs to be adjusted so when changes are made to the viewport, floating headshot of player shrinks and moves to the left accordingly. 
  **Note:** This will be more convenient to adjust once additional playerstats are added in each playerCard. 