### PR TITLE
Fixed playerCard mobile responsiveness

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -11,8 +11,8 @@
 }
 
 .teamPage-container {
-    padding-left: 7em;
-    padding-right: 7em;
+    /* padding-left: 7em;
+    padding-right: 7em; */
 }
 
 .teamCard {
@@ -35,13 +35,14 @@
 
 #playerCard {
     width: 20rem;
-    display: inline-block;
+    height: 17.8rem;
+    display: flex;
+    align-items: center;
     text-align: center;
-    margin: auto;
+    margin-left: 1.25em;
+    margin-right: 1.25em;
     margin-bottom: 8rem;
     color: var(--teamColor);
-    /* test */
-    position: relative;
 }
 
 .image-cropper {
@@ -52,7 +53,6 @@
     border-radius: 50%;
     background-color: white;
     top: -15%;
-    left: 30%;
 }
 
 .image-cropper-subContainer {

--- a/views/teamPage.ejs
+++ b/views/teamPage.ejs
@@ -8,7 +8,7 @@
     <br>
     <div class="container teamPage-container">
       <div class="container-fluid">
-        <div class="row justify-content-evenly">
+        <div class="row justify-content-center">
           <!-- PLAYER CARD -->
           <%# EJS CODE %>
           <% team.slice(1).forEach(function(player) { %>
@@ -66,5 +66,5 @@
 
 <script src="https://cdn.jsdelivr.net/npm/js-cookie@rc/dist/js.cookie.min.js"></script>
 <script src="https://unpkg.com/sweetalert/dist/sweetalert.min.js"></script>
-    
-<%- include("partials/footer.ejs") %> 
+
+<%- include("partials/footer.ejs") %>


### PR DESCRIPTION
**ISSUES ADDRESSED:**
- playerCard responsiveness on mobile and floating header pictures
- playerCards with different heights if playerName is long and fills row which moves 'favorite' button underneath playerName.

**FIXES:**
- Removed padding left & right from teamPage-container.
- Changed row justify-content-evenly to row justify-content-center, then add manual margins (left & right) between player cards for adequate spacing.
- Implemented flexbox for playerCards, align-items: center to make the floating headshots of each player centered rather than using manual position CSS properties.
- Implemented a fixed height for playerCards so they're not different heights.

**TODO:**
- Adjust 'favorite' button in a fixed position in the playerCard. Currently, if a playerName is too long the 'favorite' button moves to the next block, causing the social media icons to be moved too far down in the playerCard. 